### PR TITLE
Riset phpunit laravel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Homestead.json
 Homestead.yaml
 npm-debug.log
 yarn-error.log
+/report

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,9 @@
         ],
         "post-create-project-cmd": [
             "@php artisan key:generate --ansi"
+        ],
+        "test": [
+            "XDEBUG_MODE=coverage vendor/bin/phpunit"
         ]
     }
 }

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Model;
+use Faker\Generator as Faker;
+use Psy\Util\Str;
+
+$factory->define(Model::class, function (Faker $faker) {
+    return [
+        'name' => $faker->name,
+        'status' => $faker->randomElements(['active','not_active']),
+        'description' => Str::random(50)
+    ];
+});

--- a/database/factories/AssetFactory.php
+++ b/database/factories/AssetFactory.php
@@ -2,14 +2,13 @@
 
 /** @var \Illuminate\Database\Eloquent\Factory $factory */
 
-use App\Model;
+use App\Models\Asset;
 use Faker\Generator as Faker;
-use Psy\Util\Str;
 
-$factory->define(Model::class, function (Faker $faker) {
+$factory->define(Asset::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
-        'status' => $faker->randomElements(['active','not_active']),
-        'description' => Str::random(50)
+        'status' => $faker->randomElement(['active','not_active']),
+        'description' => $faker->sentence
     ];
 });

--- a/database/factories/ReservationFactory.php
+++ b/database/factories/ReservationFactory.php
@@ -1,0 +1,18 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use App\Models\Reservation;
+use Faker\Generator as Faker;
+
+$factory->define(Reservation::class, function (Faker $faker) {
+    return [
+        'title' => $faker->name,
+        'description' => $faker->sentence,
+        'asset_id' => $faker->randomNumber(),
+        'date' => $faker->date(),
+        'start_time' => $faker->time(),
+        'end_time' => $faker->time(),
+        'approval_status' => $faker->randomElement(['already_approved','not_yet_approved','rejected'])
+    ];
+});

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -20,7 +20,9 @@ use Illuminate\Support\Str;
 $factory->define(User::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
+        'username' => $faker->unique()->name,
         'email' => $faker->unique()->safeEmail,
+        'role' => $faker->randomElement(['admin_reservasi,./','employee_reservasi']),
         'email_verified_at' => now(),
         'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
         'remember_token' => Str::random(10),

--- a/database/migrations/2021_01_26_232330_add_column_role_in_users_table.php
+++ b/database/migrations/2021_01_26_232330_add_column_role_in_users_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnRoleInUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('username')->after('password')->nullable();
+            $table->string('role')->after('username')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('username');
+            $table->dropColumn('role');
+        });
+    }
+}

--- a/database/seeds/AssetSeeder.php
+++ b/database/seeds/AssetSeeder.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Asset;
 use Illuminate\Database\Seeder;
 
 class AssetSeeder extends Seeder
@@ -11,29 +12,8 @@ class AssetSeeder extends Seeder
      */
     public function run()
     {
-        \DB::table('assets')->delete();
-
-        \DB::table('assets')->insert(array (
-            0 =>
-            array (
-                'id' => 1,
-                'name' => 'Zoom Meeting',
-                'status' => 'active',
-                'description' => 'Resources of Digital Room',
-                'deleted_at' => NULL,
-                'created_at' => NULL,
-                'updated_at' => '2018-05-23 18:33:57',
-            ),
-            1 =>
-            array (
-                'id' => 2,
-                'name' => 'Google Meet',
-                'status' => 'not_active',
-                'description' => 'Resources of Digital Room',
-                'deleted_at' => NULL,
-                'created_at' => NULL,
-                'updated_at' => '2018-05-23 18:33:57',
-            ),
-        ));
+        factory(Asset::class, 5)->create()->each(function ($asset) {
+            $asset->save();
+        });
     }
 }

--- a/database/seeds/AssetSeeder.php
+++ b/database/seeds/AssetSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class AssetSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        \DB::table('assets')->delete();
+
+        \DB::table('assets')->insert(array (
+            0 =>
+            array (
+                'id' => 1,
+                'name' => 'Zoom Meeting',
+                'status' => 'active',
+                'description' => 'Resources of Digital Room',
+                'deleted_at' => NULL,
+                'created_at' => NULL,
+                'updated_at' => '2018-05-23 18:33:57',
+            ),
+            1 =>
+            array (
+                'id' => 2,
+                'name' => 'Google Meet',
+                'status' => 'not_active',
+                'description' => 'Resources of Digital Room',
+                'deleted_at' => NULL,
+                'created_at' => NULL,
+                'updated_at' => '2018-05-23 18:33:57',
+            ),
+        ));
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -11,6 +11,10 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // $this->call(UsersTableSeeder::class);
+        \DB::table('assets')->delete();
+        \DB::table('users')->delete();
+
+        $this->call(AssetSeeder::class);
+        $this->call(UserSeeder::class);
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -14,7 +14,9 @@ class DatabaseSeeder extends Seeder
         \DB::table('assets')->delete();
         \DB::table('users')->delete();
 
-        $this->call(AssetSeeder::class);
-        $this->call(UserSeeder::class);
+        $this->call([
+            AssetSeeder::class,
+            UserSeeder::class
+        ]);
     }
 }

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -17,22 +17,20 @@ class UserSeeder extends Seeder
             0 =>
             array (
                 'id' => 1,
-                'name' => 'Admin Reservasi',
-                'email' => 'adminreservasi@digitalservice.id',
-                'password' => bcrypt('adminhash'),
-                'remember_token' => NULL,
-                'created_at' => NULL,
-                'updated_at' => NULL,
+                'name' => 'Admin Reservasi Digiteam',
+                'username' => 'admin@reservationdigiteam.com',
+                'password' => bcrypt('admin@reservationdigiteam.com'),
+                'email' => 'admin@reservationdigiteam.com',
+                'role' => 'admin_reservasi,./',
             ),
             1 =>
             array (
                 'id' => 2,
-                'name' => 'Employee',
-                'email' => 'employee@digitalservice.id',
-                'password' => bcrypt('employeehash'),
-                'remember_token' => NULL,
-                'created_at' => NULL,
-                'updated_at' => NULL,
+                'name' => 'Employee Account',
+                'username' => 'employee@reservationdigiteam.com',
+                'password' => bcrypt('employee@reservationdigiteam.com'),
+                'email' => 'employee@reservationdigiteam.com',
+                'role' => 'employee_reservasi',
             ),
         ));
     }

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\User;
 use Illuminate\Database\Seeder;
 
 class UserSeeder extends Seeder
@@ -11,27 +12,8 @@ class UserSeeder extends Seeder
      */
     public function run()
     {
-        \DB::table('users')->delete();
-
-        \DB::table('users')->insert(array (
-            0 =>
-            array (
-                'id' => 1,
-                'name' => 'Admin Reservasi Digiteam',
-                'username' => 'admin@reservationdigiteam.com',
-                'password' => bcrypt('admin@reservationdigiteam.com'),
-                'email' => 'admin@reservationdigiteam.com',
-                'role' => 'admin_reservasi,./',
-            ),
-            1 =>
-            array (
-                'id' => 2,
-                'name' => 'Employee Account',
-                'username' => 'employee@reservationdigiteam.com',
-                'password' => bcrypt('employee@reservationdigiteam.com'),
-                'email' => 'employee@reservationdigiteam.com',
-                'role' => 'employee_reservasi',
-            ),
-        ));
+        factory(User::class, 2)->create()->each(function ($user) {
+            $user->save();
+        });
     }
 }

--- a/database/seeds/UserSeeder.php
+++ b/database/seeds/UserSeeder.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        \DB::table('users')->delete();
+
+        \DB::table('users')->insert(array (
+            0 =>
+            array (
+                'id' => 1,
+                'name' => 'Admin Reservasi',
+                'email' => 'adminreservasi@digitalservice.id',
+                'password' => bcrypt('adminhash'),
+                'remember_token' => NULL,
+                'created_at' => NULL,
+                'updated_at' => NULL,
+            ),
+            1 =>
+            array (
+                'id' => 2,
+                'name' => 'Employee',
+                'email' => 'employee@digitalservice.id',
+                'password' => bcrypt('employeehash'),
+                'remember_token' => NULL,
+                'created_at' => NULL,
+                'updated_at' => NULL,
+            ),
+        ));
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,7 +28,8 @@
         <server name="SESSION_DRIVER" value="array"/>
     </php>
     <logging>
-      <log type="coverage-html" target="./storage/work/report/" charset="UTF-8"
-       highlight="false" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-html" target="./report" charset="UTF-8"
+            yui="true" highlight="true"
+            lowUpperBound="50" highLowerBound="80" />
     </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -27,4 +27,8 @@
         <server name="QUEUE_CONNECTION" value="sync"/>
         <server name="SESSION_DRIVER" value="array"/>
     </php>
+    <logging>
+      <log type="coverage-html" target="./storage/work/report/" charset="UTF-8"
+       highlight="false" lowUpperBound="35" highLowerBound="70"/>
+    </logging>
 </phpunit>

--- a/routes/api.php
+++ b/routes/api.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', 'HomeController');
 
 Route::group(['middleware' => ['auth:api']], function () {
-    Route::get('user', 'Settings\ProfileController@index');
+    Route::get('user', 'Settings\ProfileController@index')->name('user.get');
     Route::group(['namespace' => 'V1'], function () {
         Route::get('asset/list', 'ActiveListAssetController@index')->name('asset.list');
         Route::apiResource('asset', 'AssetController');
@@ -25,6 +25,6 @@ Route::group(['middleware' => ['auth:api']], function () {
             ->parameters([
                 'reserved' => 'reservation',
             ]);
-        Route::get('dashboard/reservation-statistic', 'DashboardController@reservationStatistic');
+        Route::get('dashboard/reservation-statistic', 'DashboardController@reservationStatistic')->name('reservation.dashboard');
     });
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,7 +17,7 @@ Route::get('/', 'HomeController');
 Route::group(['middleware' => ['auth:api']], function () {
     Route::get('user', 'Settings\ProfileController@index');
     Route::group(['namespace' => 'V1'], function () {
-        Route::get('asset/list', 'ActiveListAssetController@index');
+        Route::get('asset/list', 'ActiveListAssetController@index')->name('asset.list');
         Route::apiResource('asset', 'AssetController');
         Route::apiResource('reservation', 'ReservationController');
         Route::apiResource('reserved', 'ReservedController')

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -2,87 +2,151 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use App\User;
 use App\Models\Asset;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
 
 class AssetTest extends TestCase
 {
-     use RefreshDatabase;
-     private $user;
-     private $asset;
+    use RefreshDatabase;
+    use WithoutMiddleware;
 
-     public function setUp() :void
-     {
-         parent::setUp();
-         $this->artisan('db:seed');
+    private $user;
+    private $asset;
 
-         // 1. Create users
-         $this->user = User::find(1);
-         // 2. Create asset
-         $this->asset = Asset::find(1);
-     }
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('db:seed');
+
+        // 1. Mock users
+        $this->user = User::find(1);
+        // 2. Mock asset
+        $this->asset = Asset::find(1);
+    }
 
     /**
-     * [testIndexPage render asset page]
+     * [testIndex render asset]
      * @return void
      */
     public function testIndexAsset()
     {
-        // 1. Create mock
-        $admin = factory(User::class)->create();
+        // 1. Mock user
+        $admin = $this->user;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.index'));
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(200);
     }
 
+    /**
+     * [testIndex render asset per page by 50]
+     * @return void
+     */
+    public function testIndexAssetPerPage()
+    {
+        // 1. Mock user
+        $admin = $this->user;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.index', ['perPage' => 50]));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    /**
+     * [testIndex render asset search by name]
+     * @return void
+     */
+    public function testIndexAssetSearchByName()
+    {
+        // 1. Mock user
+        $admin = $this->user;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.index', ['name' => 'zoom']));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    /**
+     * [testIndex render asset by status]
+     * @return void
+     */
+    public function testIndexAssetSearchByStatus()
+    {
+        // 1. Mock user
+        $admin = $this->user;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.index', ['status' => 'active']));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    /**
+     * [testShowAsset render asset by id]
+     *
+     * @return void
+     */
     public function testShowAsset()
     {
         // 1. Create mock
-        $admin = factory(User::class)->create();
+        $admin = $this->user;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.show', 1));
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(200);
     }
 
+    /**
+     * [testStoreAsset mock a store asset function]
+     *
+     * @return void
+     */
     public function testStoreAsset()
     {
         // 1. Create mock
-        $admin = factory(User::class)->create();
+        $admin = $this->user;
 
         $data = [
             'name' => 'Jabar Command Center',
             'status' => 'active',
-            'description' => 'JDS Team'
+            'description' => 'JDS Team',
         ];
 
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('asset.store'), $data);
+        $response = $this->actingAs($admin)->post(route('asset.store'), $data);
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(201);
     }
 
+    /**
+     * [testStoreAsset mock a delete asset function]
+     *
+     * @return void
+     */
     public function testDestroyAsset()
     {
         // 1. Create mock
-        $admin = factory(User::class)->create();
+        $admin = $this->user;
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('asset.destroy', 1));
+        $response = $this->actingAs($admin)->delete(route('asset.destroy', 1));
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(200);
     }
 
+    /**
+     * [testStoreAsset render active list asset]
+     *
+     * @return void
+     */
     public function testActiveListAsset()
     {
         // 1. Create mock
-        $admin = factory(User::class)->create();
+        $admin = $this->user;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.list'));
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(200);
     }
 }

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -13,18 +13,14 @@ class AssetTest extends TestCase
     use RefreshDatabase;
     use WithoutMiddleware;
 
-    private $user;
-    private $asset;
-
     public function setUp(): void
     {
         parent::setUp();
         $this->artisan('db:seed');
 
-        // 1. Mock users
-        $this->user = User::find(1);
-        // 2. Mock asset
-        $this->asset = Asset::find(1);
+        // Provide mocking data for testing
+        $this->asset = factory(Asset::class)->create();
+        $this->admin = factory(User::class)->create(['role' => 'admin_reservasi,./']);
     }
 
     /**
@@ -33,8 +29,8 @@ class AssetTest extends TestCase
      */
     public function testIndexAsset()
     {
-        // 1. Mock user
-        $admin = $this->user;
+        // 1. Mock data
+        $admin = $this->admin;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.index'));
         // 3. Verify and Assertion
@@ -47,8 +43,8 @@ class AssetTest extends TestCase
      */
     public function testIndexAssetPerPage()
     {
-        // 1. Mock user
-        $admin = $this->user;
+        // 1. Mock data
+        $admin = $this->admin;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.index', ['perPage' => 50]));
         // 3. Verify and Assertion
@@ -61,8 +57,8 @@ class AssetTest extends TestCase
      */
     public function testIndexAssetSearchByName()
     {
-        // 1. Mock user
-        $admin = $this->user;
+        // 1. Mock data
+        $admin = $this->admin;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.index', ['name' => 'zoom']));
         // 3. Verify and Assertion
@@ -75,8 +71,8 @@ class AssetTest extends TestCase
      */
     public function testIndexAssetSearchByStatus()
     {
-        // 1. Mock user
-        $admin = $this->user;
+        // 1. Mock data
+        $admin = $this->admin;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.index', ['status' => 'active']));
         // 3. Verify and Assertion
@@ -91,9 +87,9 @@ class AssetTest extends TestCase
     public function testShowAsset()
     {
         // 1. Create mock
-        $admin = $this->user;
+        $admin = $this->admin;
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('asset.show', 1));
+        $response = $this->actingAs($admin)->get(route('asset.show', $this->asset));
         // 3. Verify and Assertion
         $response->assertStatus(200);
     }
@@ -106,7 +102,7 @@ class AssetTest extends TestCase
     public function testStoreAsset()
     {
         // 1. Create mock
-        $admin = $this->user;
+        $admin = $this->admin;
 
         $data = [
             'name' => 'Jabar Command Center',
@@ -118,6 +114,9 @@ class AssetTest extends TestCase
         $response = $this->actingAs($admin)->post(route('asset.store'), $data);
         // 3. Verify and Assertion
         $response->assertStatus(201);
+        $response->assertJson(['data' => [
+            'status' => $data['status'],
+        ]]);
     }
 
     /**
@@ -128,11 +127,14 @@ class AssetTest extends TestCase
     public function testDestroyAsset()
     {
         // 1. Create mock
-        $admin = $this->user;
+        $admin = $this->admin;
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->delete(route('asset.destroy', 1));
+        $response = $this->actingAs($admin)->delete(route('asset.destroy', $this->asset));
         // 3. Verify and Assertion
         $response->assertStatus(200);
+        $response->assertJson([
+            'message' => 'Asset record deleted.',
+        ]);
     }
 
     /**
@@ -143,7 +145,7 @@ class AssetTest extends TestCase
     public function testActiveListAsset()
     {
         // 1. Create mock
-        $admin = $this->user;
+        $admin = $this->admin;
         // 2. Hit Api Endpoint
         $response = $this->actingAs($admin)->get(route('asset.list'));
         // 3. Verify and Assertion

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\User;
+use App\Models\Asset;
+
+class UserTest extends TestCase
+{
+     use RefreshDatabase;
+     private $user;
+     private $asset;
+
+     public function setUp() :void
+     {
+         parent::setUp();
+         $this->artisan('db:seed');
+
+         // 1. Create users
+         $this->user = User::find(1);
+         // 2. Create asset
+         $this->asset = Asset::find(1);
+     }
+
+    /**
+     * [testIndexPage render asset page]
+     * @return void
+     */
+    public function testIndexAsset()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.index'));
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    public function testShowAsset()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.show', 1));
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    public function testStoreAsset()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+
+        $data = [
+            'name' => 'Jabar Command Center',
+            'status' => 'active',
+            'description' => 'JDS Team'
+        ];
+
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.store', 1), $data);
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    public function testDestroyAsset()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.destroy', 1));
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    public function testActiveListAsset()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('asset.list'));
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/AssetTest.php
+++ b/tests/Feature/AssetTest.php
@@ -8,7 +8,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\User;
 use App\Models\Asset;
 
-class UserTest extends TestCase
+class AssetTest extends TestCase
 {
      use RefreshDatabase;
      private $user;
@@ -61,7 +61,7 @@ class UserTest extends TestCase
         ];
 
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('asset.store', 1), $data);
+        $response = $this->actingAs($admin)->get(route('asset.store'), $data);
         // 3. Verify and Assertion
         $response->assertStatus(401);
     }

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    use WithoutMiddleware;
+
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('db:seed');
+
+        // Provide mocking data for testing
+        $this->admin = factory(User::class)->create(['role' => 'admin_reservasi,./']);
+    }
+
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testReservationStatistic()
+    {
+        // 1. Mock user
+        $admin = $this->admin;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('reservation.dashboard'));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+        $response->assertJson(['not_yet_approved' => 0]);
+    }
+}

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
+
+class ProfileTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithoutMiddleware;
+
+    private $user;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('db:seed');
+
+        // Provide mocking data for testing
+        $this->user = factory(User::class)->create();
+    }
+
+    /**
+     * [testIndexPage render asset page]
+     * @return void
+     */
+    public function testIndexProfile()
+    {
+        // 1. Create mock
+        $user = $this->user;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($user)->get(route('user.get'));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+        $response->assertJson(['data' => ['name' => $user->name]]);
+    }
+}

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Reservation;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithFaker;
+
+use Tests\TestCase;
+
+class ReservationTest extends TestCase
+{
+    use RefreshDatabase;
+    private $user;
+
+    public function setUp() :void
+    {
+        parent::setUp();
+        $this->artisan('db:seed');
+
+        // 1. Create users
+        $this->user = User::find(1);
+        // 2. Create reservation
+        $this->reservation = Reservation::find(1);
+    }
+
+    /**
+     * [testIndexPage render asset page]
+     * @return void
+     */
+    public function testIndexReservation()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('reservation.index'));
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    public function testShowReservation()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('reservation.show', 1));
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    public function testStoreReservation()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+
+        $data = [
+            'title' => 'Study Tour',
+            'description' => 'study tour ke jabar command center',
+            'asset_id' => '1',
+            'date' => '2021-01-22',
+            'start_time' => '07:30',
+            'end_time' => '10:00'
+        ];
+
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('reservation.store'), $data);
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    public function testDestroyReservation()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create();
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('reservation.destroy', 1));
+        // 3. Verify and Assertion
+        $response->assertStatus(401);
+    }
+
+    /**
+     * A basic feature test example.
+     *
+     * @return void
+     */
+    public function testExample()
+    {
+        $response = $this->get('/');
+
+        $response->assertStatus(200);
+    }
+}

--- a/tests/Feature/ReservationTest.php
+++ b/tests/Feature/ReservationTest.php
@@ -2,27 +2,26 @@
 
 namespace Tests\Feature;
 
+use App\Models\Asset;
 use App\Models\Reservation;
 use App\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
-
+use Illuminate\Foundation\Testing\WithoutMiddleware;
 use Tests\TestCase;
 
 class ReservationTest extends TestCase
 {
     use RefreshDatabase;
-    private $user;
+    use WithoutMiddleware;
 
-    public function setUp() :void
+    public function setUp(): void
     {
         parent::setUp();
         $this->artisan('db:seed');
 
-        // 1. Create users
-        $this->user = User::find(1);
-        // 2. Create reservation
-        $this->reservation = Reservation::find(1);
+        // Provide mocking data for testing
+        $this->asset = factory(Asset::class)->create();
+        $this->employee = factory(User::class)->create(['role' => 'employee_reservasi']);
     }
 
     /**
@@ -31,63 +30,146 @@ class ReservationTest extends TestCase
      */
     public function testIndexReservation()
     {
-        // 1. Create mock
-        $admin = factory(User::class)->create();
+        // 1. Mocking data
+        $employee = $this->employee;
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('reservation.index'));
+        $response = $this->actingAs($employee)->get(route('reservation.index'));
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(200);
+    }
+
+    public function testIndexReservationSearchTitle()
+    {
+        // 1. Mocking data
+        $employee = $this->employee;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($employee)->get(route('reservation.index', ['search' => 'jabar']));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    public function testIndexReservationPerPage()
+    {
+        // 1. Mocking data
+        $employee = $this->employee;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($employee)->get(route('reservation.index', ['perPage' => 50]));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    public function testIndexReservationFilterByAsset()
+    {
+        // 1. Mocking data
+        $employee = $this->employee;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($employee)->get(route('reservation.index', ['asset_id' => 1]));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    public function testIndexReservationFilterByApprovalStatus()
+    {
+        // 1. Mocking data
+        $employee = $this->employee;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($employee)->get(route('reservation.index', ['approval_status' => 'already_approved']));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    public function testIndexReservationFilterByStartDate()
+    {
+        // 1. Mocking data
+        $employee = $this->employee;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($employee)->get(route('reservation.index', ['start_date' => '2021-01-27']));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    public function testIndexReservationFilterByEndDate()
+    {
+        // 1. Mocking data
+        $employee = $this->employee;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($employee)->get(route('reservation.index', ['end_date' => '2021-01-28']));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    public function testIndexReservationSortedBy()
+    {
+        // 1. Mocking data
+        $employee = $this->employee;
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($employee)->get(route('reservation.index', [
+            'sortBy' => 'reservation_time',
+            'date' => '2021-01-25',
+            'start_time' => '07:00',
+            'end_time' => '09:00',
+        ]));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
     }
 
     public function testShowReservation()
     {
-        // 1. Create mock
-        $admin = factory(User::class)->create();
+        // 1. Mocking data
+        $employee = $this->employee;
+        $reservation = factory(Reservation::class)->create([
+            'user_id_reservation' => $employee->id,
+            'user_fullname' => $employee->name,
+            'username' => $employee->username,
+            'asset_id' => $this->asset->id,
+            'asset_name' => $this->asset->name,
+        ]);
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('reservation.show', 1));
+        $response = $this->actingAs($employee)->get(route('reservation.show', $reservation));
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(200);
     }
 
     public function testStoreReservation()
     {
-        // 1. Create mock
-        $admin = factory(User::class)->create();
-
+        // 1. Mocking data
+        $employee = $this->employee;
         $data = [
-            'title' => 'Study Tour',
-            'description' => 'study tour ke jabar command center',
-            'asset_id' => '1',
+            'title' => 'Jabar Command Center',
+            'description' => 'Study Tour',
+            'asset_id' => $this->asset->id,
             'date' => '2021-01-22',
             'start_time' => '07:30',
-            'end_time' => '10:00'
+            'end_time' => '10:00',
         ];
 
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('reservation.store'), $data);
+        $response = $this->actingAs($employee)->post(route('reservation.store'), $data);
         // 3. Verify and Assertion
-        $response->assertStatus(401);
+        $response->assertStatus(201);
+        $response->assertJson(['data' => [
+            'title' => $data['title'],
+        ]]);
     }
 
     public function testDestroyReservation()
     {
-        // 1. Create mock
-        $admin = factory(User::class)->create();
+        // 1. Mocking data
+        $employee = $this->employee;
+        $asset = factory(Asset::class)->create();
+        $reservation = factory(Reservation::class)->create([
+            'user_id_reservation' => $employee->id,
+            'user_fullname' => $employee->name,
+            'username' => $employee->username,
+            'asset_id' => $asset->id,
+            'asset_name' => $asset->name,
+        ]);
+
         // 2. Hit Api Endpoint
-        $response = $this->actingAs($admin)->get(route('reservation.destroy', 1));
+        $this->expectException('Symfony\Component\HttpKernel\Exception\HttpException');
+        $this->withoutExceptionHandling();
+        $response = $this->actingAs($employee)->delete(route('reservation.destroy', $reservation->id));
         // 3. Verify and Assertion
-        $response->assertStatus(401);
-    }
-
-    /**
-     * A basic feature test example.
-     *
-     * @return void
-     */
-    public function testExample()
-    {
-        $response = $this->get('/');
-
         $response->assertStatus(200);
     }
 }

--- a/tests/Feature/ReservedTest.php
+++ b/tests/Feature/ReservedTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Asset;
+use App\Models\Reservation;
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\WithoutMiddleware;
+use Tests\TestCase;
+
+class ReservedTest extends TestCase
+{
+    use RefreshDatabase;
+    use WithoutMiddleware;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('db:seed');
+    }
+
+    /**
+     * [testIndexPage render asset page]
+     * @return void
+     */
+    public function testIndexReserved()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create(['role' => 'admin_reservasi,./']);
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->get(route('reserved.index'));
+        // 3. Verify and Assertion
+        $response->assertStatus(200);
+    }
+
+    public function testUpdateReserved()
+    {
+        // 1. Create mock
+        $admin = factory(User::class)->create(['role' => 'admin_reservasi,./']);
+        $employee = factory(User::class)->create(['role' => 'employee_reservasi']);
+        $asset = factory(Asset::class)->create();
+        $reservation = factory(Reservation::class)->create([
+            'user_id_reservation' => $employee->id,
+            'user_fullname' => $employee->name,
+            'username' => $employee->username,
+            'asset_id' => $asset->id,
+            'asset_name' => $asset->name,
+        ]);
+
+        $data = [
+            'note' => 'Oke',
+            'approval_status' => 'already_approved',
+            'approval_date' => '2021-01-28',
+            'user_id_updated' => $admin->id,
+        ];
+
+        // 2. Hit Api Endpoint
+        $response = $this->actingAs($admin)->put(route('reserved.update', $reservation), $data);
+        // 3. Verify and Assertion
+        $response->assertStatus(403);
+    }
+}

--- a/tests/SeedDatabase.php
+++ b/tests/SeedDatabase.php
@@ -1,0 +1,71 @@
+<?php
+namespace Tests;
+
+use Illuminate\Database\Seeder;
+use Illuminate\Contracts\Console\Kernel;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+trait SeedDatabase
+{
+    /**
+     * Seeds the database.
+     *
+     * @return void
+     */
+    public function seedDatabase()
+    {
+        if (! SeedDatabaseState::$seeded) {
+            $this->runSeeders(SeedDatabaseState::$seeders);
+            $this->syncTransactionTraits();
+            if (SeedDatabaseState::$seedOnce) {
+                SeedDatabaseState::$seeded = true;
+            }
+        }
+    }
+    /**
+     * Calls specific seeders if possible.
+     *
+     * @param array $seeders
+     */
+    public function runSeeders(array $seeders)
+    {
+        if (empty($seeders)) {
+            $this->artisan('db:seed');
+            $this->app[Kernel::class]->setArtisan(null);
+            return;
+        }
+        $this->getSeederInstance()->call($seeders);
+    }
+    /**
+     * Persists the seed and begins a new transaction
+     * where the rollback has been already registered in Transaction traits.
+     *
+     * @return void
+     */
+    public function syncTransactionTraits()
+    {
+        $uses = array_flip(class_uses_recursive(static::class));
+        if (isset($uses[RefreshDatabase::class]) || isset($uses[DatabaseTransactions::class])) {
+            $database = $this->app->make('db');
+            foreach ($this->connectionsToTransact() as $name) {
+                $database->connection($name)->commit();
+                $database->connection($name)->beginTransaction();
+            }
+        }
+    }
+    /**
+     * Builds a quick seeder instance.
+     *
+     * @return Seeder
+     */
+    private function getSeederInstance()
+    {
+        return
+            new class() extends Seeder {
+                public function run()
+                {
+                }
+            };
+    }
+}

--- a/tests/SeedDatabaseState.php
+++ b/tests/SeedDatabaseState.php
@@ -1,0 +1,24 @@
+<?php
+namespace Tests;
+
+class SeedDatabaseState
+{
+    /**
+     * Indicates if the test database has been seeded.
+     *
+     * @var bool
+     */
+    public static $seeded = false;
+    /**
+     * Indicates if the seeders should run once at the beginning of the suite.
+     *
+     * @var bool
+     */
+    public static $seedOnce = true;
+    /**
+     * Runs only these registered seeders instead of running all seeders.
+     *
+     * @var array
+     */
+    public static $seeders = [];
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,10 +1,15 @@
 <?php
-
 namespace Tests;
 
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    use CreatesApplication;
+    use CreatesApplication, RefreshDatabase, SeedDatabase;
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->seedDatabase();
+    }
 }


### PR DESCRIPTION
Trying to implement php unit on mini project to up coverage test of application

![Screenshot from 2021-01-27 08-17-53](https://user-images.githubusercontent.com/32012588/105928382-73330e80-6078-11eb-8f28-8fd695aff3ad.png)

Overview :
- phpunit (./vendor/bin/phpunit) saya tuangkan ke composer object `scripts` sehingga untuk mencoba menjalankan unit test hanya dengan perintah `composer test`
- use XDEBUG dan menggenerate folder /report yang berisi coverage html
- use faker for factory
- use seeder for generate data master

Note:
-menggunakan `Illuminate\Foundation\Testing\WithoutMiddleware` (untuk by pass auth keycloak :dancers: )

cc: @jabardigitalservice/jds-backend @yohang88 @rindibudiaramdhan @ayocodingit 