### PR TITLE
fixing description always null when store an asset

### DIFF
--- a/app/Http/Requests/StoreAssetRequest.php
+++ b/app/Http/Requests/StoreAssetRequest.php
@@ -30,7 +30,8 @@ class StoreAssetRequest extends FormRequest
             'name' => 'required|unique:assets,name,NULL,id,deleted_at,NULL',
             'status' => ['required', new EnumValueRule(AssetStatusEnum::class)],
             'capacity' => 'required|numeric',
-            'resource_type' => ['required', new EnumValueRule(ResourceTypeEnum::class)]
+            'resource_type' => ['required', new EnumValueRule(ResourceTypeEnum::class)],
+            'description' => 'nullable'
         ];
     }
 }


### PR DESCRIPTION
Refer to task --> https://trello.com/c/8RU2hcyx

Overview:
- Fixing field description always null every store an asset

Note:
- This caused by action controller using` $request->validated()` when store an asset (description field is not included) so i put description field with `nullable` value