### PR TITLE
Re-fix email header title

### DIFF
--- a/resources/views/emails/ccReservationNotification.blade.php
+++ b/resources/views/emails/ccReservationNotification.blade.php
@@ -1,5 +1,5 @@
 @component('mail::message')
-# {{ ($reservation->approval_status == 'REJECTED') ? 'Status Permohonan' : 'Persetujuan' }} Reservasi Command Center
+# {{ ($reservation->approval_status == 'ALREADY_APPROVED') ? 'Persutujuan' : 'Status Permohonan' }} Reservasi Command Center
 
 Terima kasih Anda sudah melakukan permohonan reservasi Command Center.
 Melalui surat elektronik ini, berdasarkan data reservasi yang kami terima yaitu:


### PR DESCRIPTION
Mempebaiki email header title (request QA)

- [x] Merubah `email header title` pada `email template` untuk pengajuan yang disetujui menjadi **Persutujuan Reservasi Command Center** dan untuk pengajuan yang masih dalam proses & ditolak menjadi **Status Permohonan Reservasi Command Center**

CC : @jabardigitalservice/jds-backend @yohang88 @samudra-ajri 