### PR TITLE
modify the date validation

### DIFF
--- a/app/Http/Requests/StoreCommandCenterCloseDateRequest.php
+++ b/app/Http/Requests/StoreCommandCenterCloseDateRequest.php
@@ -24,7 +24,7 @@ class StoreCommandCenterCloseDateRequest extends FormRequest
     public function rules()
     {
         return [
-            'date' => 'required|date',
+            'date' => 'required|date|after_or_equal:today|unique:command_center_close_dates',
             'note' => 'required',
         ];
     }

--- a/app/Http/Requests/UpdateCommandCenterCloseDateRequest.php
+++ b/app/Http/Requests/UpdateCommandCenterCloseDateRequest.php
@@ -24,7 +24,7 @@ class UpdateCommandCenterCloseDateRequest extends FormRequest
     public function rules()
     {
         return [
-            'date' => 'date',
+            'date' => 'date|after_or_equal:today|unique:command_center_close_dates',
         ];
     }
 }

--- a/app/Http/Requests/UpdateCommandCenterCloseDateRequest.php
+++ b/app/Http/Requests/UpdateCommandCenterCloseDateRequest.php
@@ -24,7 +24,7 @@ class UpdateCommandCenterCloseDateRequest extends FormRequest
     public function rules()
     {
         return [
-            'date' => 'date|after_or_equal:today|unique:command_center_close_dates',
+            'date' => 'required|date|after_or_equal:today|unique:command_center_close_dates,date,' . $this->close_day->id,
         ];
     }
 }


### PR DESCRIPTION
Modify the date validation for the Command Center reservation closed dates.
- date must be unique
- admin could not input the passed days

@jabardigitalservice/jds-backend