### PR TITLE
Bugfix - add order by date asc on update reservation return function

### DIFF
--- a/app/Listeners/CreateZoomMeetingRecurring.php
+++ b/app/Listeners/CreateZoomMeetingRecurring.php
@@ -165,6 +165,7 @@ class CreateZoomMeetingRecurring
         return tap(Reservation::where('recurring_id', $reservation->recurring_id)
                     ->where('asset_id', $reservation->asset->id))
                     ->update(['join_url' => $createZoomMeeting->join_url])
+                    ->orderBy('date', 'asc')
                     ->first();
     }
 


### PR DESCRIPTION
# Overview

Add order by ascending on after tap function on update reservation to get first row by date selected

CC : @jabardigitalservice/jds-backend 